### PR TITLE
Chore: upgrade mongo to 4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM mongo:4.4
 
-CMD ["mongod", "--nojournal", "--smallfiles", "--replSet", "rs0"]
+CMD ["mongod", "--replSet", "rs0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM mongo:4.4
 
-CMD ["mongod", "--nojournal", "--noprealloc", "--smallfiles", "--replSet", "rs0"]
+CMD ["mongod", "--nojournal", "--smallfiles", "--replSet", "rs0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM mongo:latest
+FROM mongo:4.4
 
 CMD ["mongod", "--nojournal", "--noprealloc", "--smallfiles", "--replSet", "rs0"]

--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ jobs:
           MONGO_URL: "mongodb://localhost:27017/test"
           MONGO_OPLOG_URL: "mongodb://localhost:27017/local?authSource=test"
 ```
+
+## Building and releasing a version
+This example shows how to push a new `ci-mongo` image into the `veho` namespace and applying a tag, `4.4`.
+```
+docker build ./ -t veho/ci-mongo:4.4
+docker push veho/ci-mongo:4.4
+```


### PR DESCRIPTION
Upgrade to Mongo v4.4. Remove some CLI options that are no longer supported or incompatible with WiredTiger.

per https://trello.com/c/46yZI1S5/892-upgrade-to-mongo-4x